### PR TITLE
typo in aac channel configuration?

### DIFF
--- a/bitmovin/resources/enums/aac_channel_layout.py
+++ b/bitmovin/resources/enums/aac_channel_layout.py
@@ -4,7 +4,7 @@ import enum
 class AACChannelLayout(enum.Enum):
     NONE = 'NONE'
     CL_MONO = 'MONO'
-    CL_STEREO = 'CL_STEREO'
+    CL_STEREO = 'STEREO'
     CL_2_1 = '2.1'
     CL_SURROUND = 'SURROUND'
     CL_3_1 = '3.1'


### PR DESCRIPTION
This PR may be unnecessary, however I did notice when looking through both the Python and PHP APIs that this string didn't seem to matchup.  Feel free to close.