### PR TITLE
sets MVPredictionMode default to AUTO instead of SPATIAL

### DIFF
--- a/bitmovin/resources/enums/mv_prediction_mode.py
+++ b/bitmovin/resources/enums/mv_prediction_mode.py
@@ -9,4 +9,4 @@ class MVPredictionMode(enum.Enum):
 
     @staticmethod
     def default():
-        return MVPredictionMode.SPATIAL
+        return MVPredictionMode.AUTO


### PR DESCRIPTION
The Python client sets the mvPredictionMode default to "SPATIAL" whereas the other clients default to "AUTO".