### PR TITLE
Updated examples create_simple_vp9_encoding.py

### DIFF
--- a/examples/encoding/create_simple_vp9_encoding.py
+++ b/examples/encoding/create_simple_vp9_encoding.py
@@ -3,7 +3,7 @@ import datetime
 from bitmovin import Bitmovin, Encoding, HTTPSInput, S3Output, VP9CodecConfiguration, \
     AACCodecConfiguration, StreamInput, SelectionMode, Stream, EncodingOutput, ACLEntry, ACLPermission, \
     FMP4Muxing, WebMMuxing, MuxingStream, CloudRegion, DashManifest, FMP4Representation, WebMRepresentation, Period, \
-    VideoAdaptationSet, AudioAdaptationSet, AWSCloudRegion, WebMRepresentationType
+    VideoAdaptationSet, AudioAdaptationSet, AWSCloudRegion, WebMRepresentationType, FMP4RepresentationType
 from bitmovin.errors import BitmovinError
 
 API_KEY = '<INSERT_YOUR_API_KEY>'
@@ -164,7 +164,7 @@ def main():
                                                                                adaptationset_id=video_adaptation_set.id
                                                                                ).resource
 
-    fmp4_representation_audio = FMP4Representation(type=WebMRepresentationType.TEMPLATE,
+    fmp4_representation_audio = FMP4Representation(type=FMP4RepresentationType.TEMPLATE,
                                                    encoding_id=encoding.id,
                                                    muxing_id=audio_muxing.id,
                                                    segment_path='audio/')


### PR DESCRIPTION
fixing bad type for FMP4Representation when creating the manifest

I had this error when using this script
`bitmovin.errors.invalid_type_error.InvalidTypeError: Invalid type <enum 'WebMRepresentationType'> for 'type': must be either str or FMP4RepresentationType!`
I fixed it using the FMP4RepresentationType
