### PR TITLE
Handle PlayReadyMethod enums serialization

### DIFF
--- a/bitmovin/resources/models/encodings/drms/playready_drm.py
+++ b/bitmovin/resources/models/encodings/drms/playready_drm.py
@@ -1,15 +1,35 @@
 from .drm import DRM
+from bitmovin.resources.enums import PlayReadyMethod
+from bitmovin.utils import Serializable
 
 
-class PlayReadyDRM(DRM):
+class PlayReadyDRM(DRM, Serializable):
 
     def __init__(self, key_seed, kid, method, la_url=None, outputs=None, id_=None, custom_data=None,
                  name=None, description=None):
         super().__init__(id_=id_, custom_data=custom_data, outputs=outputs, name=name, description=description)
+        self._method = None
+
         self.method = method
         self.keySeed = key_seed
         self.kid = kid
         self.laUrl = la_url
+
+    @property
+    def method(self):
+        return self._method
+
+    @method.setter
+    def method(self, value):
+        if value is None:
+            return
+        if isinstance(value, str):
+            self._method = value
+        elif isinstance(value, PlayReadyMethod):
+            self._method = value.value
+        else:
+            raise InvalidTypeError(
+                'Invalid type {} for method: must be either str or PlayReadyMethod!'.format(type(value)))
 
     @classmethod
     def parse_from_json_object(cls, json_object):
@@ -29,3 +49,9 @@ class PlayReadyDRM(DRM):
                                      name=name, description=description)
 
         return playready_drm
+
+    def serialize(self):
+        serialized = super().serialize()
+        serialized['method'] = self._method
+
+        return serialized

--- a/tests/bitmovin/services/encodings/drms/playready_drm_tests.py
+++ b/tests/bitmovin/services/encodings/drms/playready_drm_tests.py
@@ -5,6 +5,7 @@ from bitmovin import Bitmovin, Response, Stream, StreamInput, EncodingOutput, AC
     FMP4Muxing, MuxingStream, PlayReadyDRM, SelectionMode, ACLPermission
 from bitmovin.errors import BitmovinApiError
 from tests.bitmovin import BitmovinTestCase
+from bitmovin.resources.enums import PlayReadyMethod
 
 
 class PlayReadyDRMTests(BitmovinTestCase):
@@ -31,6 +32,21 @@ class PlayReadyDRMTests(BitmovinTestCase):
         fmp4_muxing = self._create_muxing()  # type: FMP4Muxing
         self.assertIsNotNone(fmp4_muxing.id)
         sample_drm = self._get_sample_drm_playready()
+        sample_drm.outputs = fmp4_muxing.outputs
+
+        created_drm_response = self.bitmovin.encodings.Muxing.FMP4.DRM.PlayReady.create(
+            object_=sample_drm, encoding_id=self.sampleEncoding.id, muxing_id=fmp4_muxing.id)
+
+        self.assertIsNotNone(created_drm_response)
+        self.assertIsNotNone(created_drm_response.resource)
+        self.assertIsNotNone(created_drm_response.resource.id)
+        drm_resource = created_drm_response.resource  # type: PlayReadyDRM
+        self._compare_drms(sample_drm, drm_resource)
+
+    def test_create_playready_piff(self):
+        fmp4_muxing = self._create_muxing()  # type: FMP4Muxing
+        self.assertIsNotNone(fmp4_muxing.id)
+        sample_drm = self._get_sample_drm_playready_piff()
         sample_drm.outputs = fmp4_muxing.outputs
 
         created_drm_response = self.bitmovin.encodings.Muxing.FMP4.DRM.PlayReady.create(
@@ -211,6 +227,17 @@ class PlayReadyDRMTests(BitmovinTestCase):
                            method=playready_drm_settings[0].get('method'),
                            la_url=playready_drm_settings[0].get('laUrl'),
                            name='Sample Playready DRM')
+
+        return drm
+
+    def _get_sample_drm_playready_piff(self):
+        playready_drm_settings = self.settings.get('sampleObjects').get('drmConfigurations').get('PlayReady')
+
+        drm = PlayReadyDRM(key_seed=playready_drm_settings[0].get('keySeed'),
+                           kid=playready_drm_settings[0].get('kid'),
+                           method=PlayReadyMethod.PIFF_CTR,
+                           la_url=playready_drm_settings[0].get('laUrl'),
+                           name='Sample Playready PIFF DRM')
 
         return drm
 


### PR DESCRIPTION
This fixes a pickle error when serializing PlayReadyMethod enum to JSON. PlayReadyDRM now has a setter property which uses the string value of the enum. It also adds a PlayReady unit test that uses a PIFF CTR enum value to test this use.