### PR TITLE
Add PlayReady support to Smooth Streaming packaging

### DIFF
--- a/bitmovin/resources/models/manifests/smooth/__init__.py
+++ b/bitmovin/resources/models/manifests/smooth/__init__.py
@@ -1,3 +1,4 @@
 from .smooth_manifest import SmoothManifest
 from .abstract_mp4_representation import AbstractMP4Representation
 from .mp4_representation import MP4Representation
+from .content_protection import SmoothContentProtection

--- a/bitmovin/resources/models/manifests/smooth/content_protection.py
+++ b/bitmovin/resources/models/manifests/smooth/content_protection.py
@@ -1,0 +1,22 @@
+from bitmovin.resources.models import AbstractModel
+
+
+# having to call it to avoid clash with DASH version
+class SmoothContentProtection(AbstractModel):
+
+    def __init__(self, encoding_id, muxing_id, drm_id, id_=None, custom_data=None):
+        super().__init__(id_=id_, custom_data=custom_data)
+        self.encodingId = encoding_id
+        self.muxingId = muxing_id
+        self.drmId = drm_id
+
+    @classmethod
+    def parse_from_json_object(cls, json_object):
+        id_ = json_object['id']
+        custom_data = json_object.get('customData')
+        encoding_id = json_object['encodingId']
+        muxing_id = json_object['muxingId']
+        drm_id = json_object['drmId']
+        content_protection = SmoothContentProtection(id_=id_, custom_data=custom_data,
+                                               encoding_id=encoding_id, muxing_id=muxing_id, drm_id=drm_id)
+        return content_protection

--- a/bitmovin/services/encodings/mp4_drm_service.py
+++ b/bitmovin/services/encodings/mp4_drm_service.py
@@ -1,0 +1,18 @@
+from .drm_service import DRMService
+from .widevine_drm_service import WidevineDRM
+from .playready_drm_service import PlayReadyDRM
+from .marlin_drm_service import MarlinDRM
+from .clearkey_drm_service import ClearKeyDRM
+from .cenc_drm_service import CENCDRM
+
+
+class MP4DRMService(DRMService):
+    MUXING_TYPE_URL = 'mp4'
+
+    def __init__(self, http_client):
+        super().__init__(http_client=http_client)
+        self.Widevine = WidevineDRM(http_client=http_client, muxing_type_url=self.MUXING_TYPE_URL)
+        self.PlayReady = PlayReadyDRM(http_client=http_client, muxing_type_url=self.MUXING_TYPE_URL)
+        self.Marlin = MarlinDRM(http_client=http_client, muxing_type_url=self.MUXING_TYPE_URL)
+        self.ClearKey = ClearKeyDRM(http_client=http_client, muxing_type_url=self.MUXING_TYPE_URL)
+        self.CENC = CENCDRM(http_client=http_client, muxing_type_url=self.MUXING_TYPE_URL)

--- a/bitmovin/services/encodings/mp4_muxing_service.py
+++ b/bitmovin/services/encodings/mp4_muxing_service.py
@@ -3,12 +3,14 @@ from bitmovin.errors import BitmovinApiError, InvalidStatusError
 from bitmovin.resources.models import MP4MuxingInformation
 from bitmovin.resources.models import MP4Muxing as MP4MuxingResource
 from .generic_muxing_service import GenericMuxingService
+from .mp4_drm_service import MP4DRMService
 
 
 class MP4Muxing(GenericMuxingService):
 
     def __init__(self, http_client):
         super().__init__(http_client=http_client, type_url='mp4', resource_class=MP4MuxingResource)
+        self.DRM = MP4DRMService(http_client=http_client)
 
     def retrieve_information(self, encoding_id, muxing_id):
         self.relative_url = self._get_endpoint_url(encoding_id=encoding_id)

--- a/bitmovin/services/manifests/smooth_content_protection_service.py
+++ b/bitmovin/services/manifests/smooth_content_protection_service.py
@@ -1,0 +1,37 @@
+from bitmovin.resources import SmoothContentProtection
+from bitmovin.errors import MissingArgumentError, FunctionalityNotAvailableError
+from bitmovin.services.rest_service import RestService
+
+
+class SmoothContentProtectionService(RestService):
+    BASE_ENDPOINT_URL = 'encoding/manifests/smooth/{manifest_id}/contentprotection'
+
+    def __init__(self, http_client):
+        self.resource_class = SmoothContentProtection
+        super().__init__(http_client=http_client, relative_url=self.BASE_ENDPOINT_URL, class_=self.resource_class)
+
+    def _get_endpoint_url(self, manifest_id):
+        if not manifest_id:
+            raise MissingArgumentError('manifest_id must be given')
+        endpoint_url = self.BASE_ENDPOINT_URL \
+            .replace('{manifest_id}', manifest_id)
+        return endpoint_url
+
+    def create(self, object_, manifest_id):
+        self.relative_url = self._get_endpoint_url(manifest_id=manifest_id)
+        return super().create(object_)
+
+    def delete(self, manifest_id, protection_id):
+        self.relative_url = self._get_endpoint_url(manifest_id=manifest_id)
+        return super().delete(id_=protection_id)
+
+    def retrieve(self, manifest_id, protection_id):
+        self.relative_url = self._get_endpoint_url(manifest_id=manifest_id)
+        return super().retrieve(id_=protection_id)
+
+    def list(self, manifest_id, offset=None, limit=None):
+        self.relative_url = self._get_endpoint_url(manifest_id=manifest_id)
+        return super().list(offset, limit)
+
+    def retrieve_custom_data(self, manifest_id, protection_id):
+        raise FunctionalityNotAvailableError('Retrieve Custom Data is not available for Smooth Manifest Content Protection')

--- a/bitmovin/services/manifests/smooth_manifest_service.py
+++ b/bitmovin/services/manifests/smooth_manifest_service.py
@@ -1,9 +1,9 @@
 from bitmovin.resources import SmoothManifest
-
 from .manifest_control_service import ManifestControlService
 from ..rest_service import RestService
-
 from .smooth_representation_service import MP4RepresentationService
+from .smooth_content_protection_service import SmoothContentProtectionService
+
 
 class Smooth(RestService, ManifestControlService):
     BASE_ENDPOINT_URL = 'encoding/manifests/smooth'
@@ -12,3 +12,4 @@ class Smooth(RestService, ManifestControlService):
         super().__init__(http_client=http_client, relative_url=self.BASE_ENDPOINT_URL, class_=SmoothManifest)
 
         self.MP4Representation = MP4RepresentationService(http_client=http_client)
+        self.ContentProtection = SmoothContentProtectionService(http_client=http_client)

--- a/examples/encoding/create_simple_mp4_smooth_encoding.py
+++ b/examples/encoding/create_simple_mp4_smooth_encoding.py
@@ -1,7 +1,7 @@
 import datetime
 from bitmovin import Bitmovin, Encoding, S3Input, S3Output, H264CodecConfiguration, \
     AACCodecConfiguration, H264Profile, StreamInput, SelectionMode, Stream, EncodingOutput, ACLEntry, ACLPermission, \
-    MP4Muxing, MuxingStream, CloudRegion, SmoothManifest, MP4Representation
+    MP4Muxing, MuxingStream, CloudRegion, SmoothManifest, MP4Representation, Condition
 from bitmovin.errors import BitmovinError
 
 API_KEY = '<YOUR_API_KEY>'
@@ -17,6 +17,14 @@ S3_OUTPUT_BUCKETNAME = '<YOUR_S3_OUTPUT_BUCKETNAME>'
 
 date_component = str(datetime.datetime.now()).replace(' ', '_').replace(':', '-').split('.')[0].replace('_', '__')
 OUTPUT_BASE_PATH = 'output/python-smooth/{}/'.format(date_component)
+
+# Please set here the encoding profiles. You can modify height, bitrate and fps.
+encoding_profiles_h264 = [
+    dict(height=240, bitrate=400, fps=None, profile=H264Profile.HIGH),
+    dict(height=360, bitrate=800, fps=None, profile=H264Profile.HIGH),
+    dict(height=480, bitrate=1200, fps=None, profile=H264Profile.HIGH),
+    dict(height=720, bitrate=2400, fps=None, profile=H264Profile.HIGH),
+]
 
 
 def main():
@@ -39,39 +47,24 @@ def main():
 
     encoding = Encoding(name='example mp4 encoding for smooth',
                         cloud_region=CloudRegion.GOOGLE_EUROPE_WEST_1)
+
     encoding = bitmovin.encodings.Encoding.create(encoding).resource
 
-    video_codec_configuration_720p = H264CodecConfiguration(name='example_video_codec_configuration_720p',
-                                                            bitrate=2400000,
-                                                            rate=25.0,
-                                                            width=1280,
-                                                            height=720,
-                                                            profile=H264Profile.HIGH)
-    video_codec_configuration_720p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_720p).resource
+    encoding_configs = []
 
-    video_codec_configuration_480p = H264CodecConfiguration(name='example_video_codec_configuration_480p',
-                                                            bitrate=1200000,
-                                                            rate=25.0,
-                                                            width=854,
-                                                            height=480,
-                                                            profile=H264Profile.HIGH)
-    video_codec_configuration_480p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_480p).resource
-
-    video_codec_configuration_360p = H264CodecConfiguration(name='example_video_codec_configuration_360p',
-                                                            bitrate=800000,
-                                                            rate=25.0,
-                                                            width=640,
-                                                            height=360,
-                                                            profile=H264Profile.HIGH)
-    video_codec_configuration_360p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_360p).resource
-
-    video_codec_configuration_240p = H264CodecConfiguration(name='example_video_codec_configuration_240p',
-                                                            bitrate=400000,
-                                                            rate=25.0,
-                                                            width=426,
-                                                            height=240,
-                                                            profile=H264Profile.HIGH)
-    video_codec_configuration_240p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_240p).resource
+    # Iterate over all encoding profiles and create the H264 configuration with the defined height and bitrate.
+    for idx, _ in enumerate(encoding_profiles_h264):
+        profile_h264 = encoding_profiles_h264[idx]
+        encoding_config = dict(profile_h264=profile_h264)
+        h264_codec = H264CodecConfiguration(
+            name='H264 Codec {}p {}k Configuration'.format(profile_h264.get('height'),
+                                                           profile_h264.get('bitrate')),
+            bitrate=profile_h264.get('bitrate') * 1000,
+            height=profile_h264.get('height'),
+            profile=profile_h264.get('profile'),
+            rate=profile_h264.get("fps"))
+        encoding_config['h264_codec'] = bitmovin.codecConfigurations.H264.create(h264_codec).resource
+        encoding_configs.append(encoding_config)
 
     audio_codec_configuration = AACCodecConfiguration(name='example_audio_codec_configuration_english',
                                                       bitrate=128000,
@@ -81,93 +74,54 @@ def main():
     video_input_stream = StreamInput(input_id=s3_input.id,
                                      input_path=S3_INPUT_PATH,
                                      selection_mode=SelectionMode.AUTO)
+
     audio_input_stream = StreamInput(input_id=s3_input.id,
                                      input_path=S3_INPUT_PATH,
                                      selection_mode=SelectionMode.AUTO)
 
-    video_stream_720p = Stream(codec_configuration_id=video_codec_configuration_720p.id,
-                               input_streams=[video_input_stream], name='Sample Stream 720p')
-    video_stream_720p = bitmovin.encodings.Stream.create(object_=video_stream_720p,
-                                                         encoding_id=encoding.id).resource
+    # With the configurations and the input file streams are now created and muxed later on.
+    for encoding_config in encoding_configs:
+        encoding_profile = encoding_config.get("profile_h264")
+        video_stream_condition = Condition(attribute="HEIGHT", operator=">=", value=str(encoding_profile.get('height')))
+        video_stream_h264 = Stream(codec_configuration_id=encoding_config.get("h264_codec").id,
+                                   input_streams=[video_input_stream],
+                                   conditions=video_stream_condition,
+                                   name='Stream H264 {}p_{}k'.format(encoding_profile.get('height'),
+                                                                     encoding_profile.get('bitrate')))
 
-    video_stream_480p = Stream(codec_configuration_id=video_codec_configuration_480p.id,
-                               input_streams=[video_input_stream], name='Sample Stream 480p')
-    video_stream_480p = bitmovin.encodings.Stream.create(object_=video_stream_480p,
-                                                         encoding_id=encoding.id).resource
+        encoding_config['h264_stream'] = bitmovin.encodings.Stream.create(object_=video_stream_h264,
+                                                                          encoding_id=encoding.id).resource
 
-    video_stream_360p = Stream(codec_configuration_id=video_codec_configuration_360p.id,
-                               input_streams=[video_input_stream], name='Sample Stream 360p')
-    video_stream_360p = bitmovin.encodings.Stream.create(object_=video_stream_360p,
-                                                         encoding_id=encoding.id).resource
-
-    video_stream_240p = Stream(codec_configuration_id=video_codec_configuration_240p.id,
-                               input_streams=[video_input_stream], name='Sample Stream 240p')
-    video_stream_240p = bitmovin.encodings.Stream.create(object_=video_stream_240p,
-                                                         encoding_id=encoding.id).resource                                                     
-
+    audio_stream_condition = Condition(attribute="INPUTSTREAM", operator="==", value="TRUE")
     audio_stream = Stream(codec_configuration_id=audio_codec_configuration.id,
-                          input_streams=[audio_input_stream], name='Sample Stream AUDIO')
-    audio_stream = bitmovin.encodings.Stream.create(object_=audio_stream,
-                                                    encoding_id=encoding.id).resource
+                          input_streams=[audio_input_stream], conditions=audio_stream_condition,
+                          name='Sample Stream AUDIO')
 
-    video_muxing_stream_720p = MuxingStream(video_stream_720p.id)
-    video_muxing_stream_480p = MuxingStream(video_stream_480p.id)
-    video_muxing_stream_360p = MuxingStream(video_stream_360p.id)
-    video_muxing_stream_240p = MuxingStream(video_stream_240p.id)
+    audio_stream = bitmovin.encodings.Stream.create(object_=audio_stream, encoding_id=encoding.id).resource
+
+    for encoding_config in encoding_configs:
+        encoding_profile = encoding_config.get("profile_h264")
+        video_muxing_stream_h264 = MuxingStream(encoding_config.get("h264_stream").id)
+        video_muxing_output_h264 = EncodingOutput(output_id=s3_output.id, output_path=OUTPUT_BASE_PATH, acl=[acl_entry])
+        video_muxing_h264 = MP4Muxing(filename='video_{}p.ismv'.format(encoding_profile.get('height')),
+                                      fragment_duration=4000, streams=[video_muxing_stream_h264],
+                                      outputs=[video_muxing_output_h264],
+                                      name='Sample Muxing {}p'.format(encoding_profile.get('height')))
+
+        encoding_config['h264_muxing'] = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_h264,
+                                                                              encoding_id=encoding.id).resource
+
     audio_muxing_stream = MuxingStream(audio_stream.id)
-
-    video_muxing_720p_output = EncodingOutput(output_id=s3_output.id,
-                                              output_path=OUTPUT_BASE_PATH,
-                                              acl=[acl_entry])
-    video_muxing_720p = MP4Muxing(filename='video_720p.ismv',
-                                  fragment_duration=4000,
-                                  streams=[video_muxing_stream_720p],
-                                  outputs=[video_muxing_720p_output],
-                                  name='Sample Muxing 720p')
-    video_muxing_720p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_720p,
-                                                             encoding_id=encoding.id).resource
-
-    video_muxing_480p_output = EncodingOutput(output_id=s3_output.id,
-                                              output_path=OUTPUT_BASE_PATH,
-                                              acl=[acl_entry])
-    video_muxing_480p = MP4Muxing(filename='video_480p.ismv',
-                                  fragment_duration=4000,
-                                  streams=[video_muxing_stream_480p],
-                                  outputs=[video_muxing_480p_output],
-                                  name='Sample Muxing 480p')
-    video_muxing_480p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_480p,
-                                                             encoding_id=encoding.id).resource
-
-    video_muxing_360p_output = EncodingOutput(output_id=s3_output.id,
-                                              output_path=OUTPUT_BASE_PATH,
-                                              acl=[acl_entry])
-    video_muxing_360p = MP4Muxing(filename='video_360p.ismv',
-                                  fragment_duration=4000,
-                                  streams=[video_muxing_stream_360p],
-                                  outputs=[video_muxing_360p_output],
-                                  name='Sample Muxing 360p')
-    video_muxing_360p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_360p,
-                                                             encoding_id=encoding.id).resource
-
-    video_muxing_240p_output = EncodingOutput(output_id=s3_output.id,
-                                              output_path=OUTPUT_BASE_PATH,
-                                              acl=[acl_entry])
-    video_muxing_240p = MP4Muxing(filename='video_240p.ismv',
-                                  fragment_duration=4000,
-                                  streams=[video_muxing_stream_240p],
-                                  outputs=[video_muxing_240p_output],
-                                  name='Sample Muxing 240p')
-    video_muxing_240p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_240p,
-                                                             encoding_id=encoding.id).resource
-
     audio_muxing_output = EncodingOutput(output_id=s3_output.id,
-                                              output_path=OUTPUT_BASE_PATH,
-                                              acl=[acl_entry])
+                                         output_path=OUTPUT_BASE_PATH,
+                                         acl=[acl_entry])
+
     audio_muxing = MP4Muxing(filename='audio.isma',
                              fragment_duration=4000,
                              streams=[audio_muxing_stream],
                              outputs=[audio_muxing_output],
                              name='Sample Muxing AUDIO')
+
     audio_muxing = bitmovin.encodings.Muxing.MP4.create(object_=audio_muxing,
                                                         encoding_id=encoding.id).resource
 
@@ -186,36 +140,25 @@ def main():
                                      client_manifest_name='example_manifest_smooth.ismc',
                                      outputs=[manifest_output],
                                      name='Sample SmoothStreaming Manifest')
+
     smooth_manifest = bitmovin.manifests.Smooth.create(object_=smooth_manifest).resource
 
     mp4_representation_audio = MP4Representation(encoding_id=encoding.id,
                                                  muxing_id=audio_muxing.id,
                                                  media_file='audio.isma')
+
     mp4_representation_audio = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
                                                                                   object_=mp4_representation_audio)
-    mp4_representation_720p = MP4Representation(encoding_id=encoding.id,
-                                                muxing_id=video_muxing_720p.id,
-                                                media_file='video_720p.ismv')
-    mp4_representation_720p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
-                                                                                 object_=mp4_representation_720p)
 
-    mp4_representation_480p = MP4Representation(encoding_id=encoding.id,
-                                                muxing_id=video_muxing_480p.id,
-                                                media_file='video_480p.ismv')
-    mp4_representation_480p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
-                                                                                 object_=mp4_representation_480p)
+    for encoding_config in encoding_configs:
+        encoding_profile = encoding_config.get("profile_h264")
+        muxing = encoding_config.get('h264_muxing')
+        mp4_representation = MP4Representation(encoding_id=encoding.id,
+                                               muxing_id=muxing.id,
+                                               media_file='video_{}p.ismv'.format(encoding_profile.get('height')))
 
-    mp4_representation_360p = MP4Representation(encoding_id=encoding.id,
-                                                muxing_id=video_muxing_360p.id,
-                                                media_file='video_360p.ismv')
-    mp4_representation_360p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
-                                                                                 object_=mp4_representation_360p)
-
-    mp4_representation_240p = MP4Representation(encoding_id=encoding.id,
-                                                muxing_id=video_muxing_240p.id,
-                                                media_file='video_240p.ismv')
-    mp4_representation_240p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
-                                                                                 object_=mp4_representation_240p)
+        encoding_config['h264_smooth'] = bitmovin.manifests.Smooth.MP4Representation.create(
+            manifest_id=smooth_manifest.id, object_=mp4_representation)
 
     bitmovin.manifests.Smooth.start(manifest_id=smooth_manifest.id)
 

--- a/examples/encoding/create_simple_mp4_smooth_playready_encoding.py
+++ b/examples/encoding/create_simple_mp4_smooth_playready_encoding.py
@@ -1,0 +1,279 @@
+import datetime
+from bitmovin import Bitmovin, Encoding, S3Input, S3Output, H264CodecConfiguration, \
+    AACCodecConfiguration, H264Profile, StreamInput, SelectionMode, Stream, EncodingOutput, ACLEntry, ACLPermission, \
+    MP4Muxing, MuxingStream, CloudRegion, SmoothManifest, MP4Representation, PlayReadyDRM, PlayReadyMethod, \
+    SmoothContentProtection
+from bitmovin.errors import BitmovinError
+
+API_KEY = '<YOUR_API_KEY>'
+
+S3_INPUT_ACCESSKEY = '<YOUR_S3_OUTPUT_ACCESSKEY>'
+S3_INPUT_SECRETKEY = '<YOUR_S3_OUTPUT_SECRETKEY>'
+S3_INPUT_BUCKETNAME = '<YOUR_S3_OUTPUT_BUCKETNAME>'
+S3_INPUT_PATH = '<YOUR_S3_INPUT_PATH>'
+
+S3_OUTPUT_ACCESSKEY = '<YOUR_S3_OUTPUT_ACCESSKEY>'
+S3_OUTPUT_SECRETKEY = '<YOUR_S3_OUTPUT_SECRETKEY>'
+S3_OUTPUT_BUCKETNAME = '<YOUR_S3_OUTPUT_BUCKETNAME>'
+
+PLAYREADY_KEYSEED = '<YOUR_CENC_KEY>'
+PLAYREADY_KID = '<YOUR_CENC_KID>'
+PLAYREADY_LA_URL = '<YOUR_PLAYREADY_LA_URL>'
+
+date_component = str(datetime.datetime.now()).replace(' ', '_').replace(':', '-').split('.')[0].replace('_', '__')
+OUTPUT_BASE_PATH = 'output/python-smooth/{}/'.format(date_component)
+
+
+def main():
+    bitmovin = Bitmovin(api_key=API_KEY)
+
+    s3_input = S3Input(access_key=S3_INPUT_ACCESSKEY,
+                       secret_key=S3_INPUT_SECRETKEY,
+                       bucket_name=S3_INPUT_BUCKETNAME,
+                       name='Sample S3 Output')
+    s3_input = bitmovin.inputs.S3.create(s3_input).resource
+
+
+    s3_output = S3Output(access_key=S3_OUTPUT_ACCESSKEY,
+                         secret_key=S3_OUTPUT_SECRETKEY,
+                         bucket_name=S3_OUTPUT_BUCKETNAME,
+                         name='Sample S3 Output')
+    s3_output = bitmovin.outputs.S3.create(s3_output).resource
+
+    acl_entry = ACLEntry(permission=ACLPermission.PUBLIC_READ)
+
+    encoding = Encoding(name='example mp4 encoding for smooth',
+                        cloud_region=CloudRegion.GOOGLE_EUROPE_WEST_1)
+    encoding = bitmovin.encodings.Encoding.create(encoding).resource
+
+    video_codec_configuration_720p = H264CodecConfiguration(name='example_video_codec_configuration_720p',
+                                                            bitrate=2400000,
+                                                            rate=25.0,
+                                                            width=1280,
+                                                            height=720,
+                                                            profile=H264Profile.HIGH)
+    video_codec_configuration_720p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_720p).resource
+
+    video_codec_configuration_480p = H264CodecConfiguration(name='example_video_codec_configuration_480p',
+                                                            bitrate=1200000,
+                                                            rate=25.0,
+                                                            width=854,
+                                                            height=480,
+                                                            profile=H264Profile.HIGH)
+    video_codec_configuration_480p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_480p).resource
+
+    video_codec_configuration_360p = H264CodecConfiguration(name='example_video_codec_configuration_360p',
+                                                            bitrate=800000,
+                                                            rate=25.0,
+                                                            width=640,
+                                                            height=360,
+                                                            profile=H264Profile.HIGH)
+    video_codec_configuration_360p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_360p).resource
+
+    video_codec_configuration_240p = H264CodecConfiguration(name='example_video_codec_configuration_240p',
+                                                            bitrate=400000,
+                                                            rate=25.0,
+                                                            width=426,
+                                                            height=240,
+                                                            profile=H264Profile.HIGH)
+    video_codec_configuration_240p = bitmovin.codecConfigurations.H264.create(video_codec_configuration_240p).resource
+
+    audio_codec_configuration = AACCodecConfiguration(name='example_audio_codec_configuration_english',
+                                                      bitrate=128000,
+                                                      rate=48000)
+    audio_codec_configuration = bitmovin.codecConfigurations.AAC.create(audio_codec_configuration).resource
+
+    video_input_stream = StreamInput(input_id=s3_input.id,
+                                     input_path=S3_INPUT_PATH,
+                                     selection_mode=SelectionMode.AUTO)
+    audio_input_stream = StreamInput(input_id=s3_input.id,
+                                     input_path=S3_INPUT_PATH,
+                                     selection_mode=SelectionMode.AUTO)
+
+    video_stream_720p = Stream(codec_configuration_id=video_codec_configuration_720p.id,
+                               input_streams=[video_input_stream], name='Sample Stream 720p')
+    video_stream_720p = bitmovin.encodings.Stream.create(object_=video_stream_720p,
+                                                         encoding_id=encoding.id).resource
+
+    video_stream_480p = Stream(codec_configuration_id=video_codec_configuration_480p.id,
+                               input_streams=[video_input_stream], name='Sample Stream 480p')
+    video_stream_480p = bitmovin.encodings.Stream.create(object_=video_stream_480p,
+                                                         encoding_id=encoding.id).resource
+
+    video_stream_360p = Stream(codec_configuration_id=video_codec_configuration_360p.id,
+                               input_streams=[video_input_stream], name='Sample Stream 360p')
+    video_stream_360p = bitmovin.encodings.Stream.create(object_=video_stream_360p,
+                                                         encoding_id=encoding.id).resource
+
+    video_stream_240p = Stream(codec_configuration_id=video_codec_configuration_240p.id,
+                               input_streams=[video_input_stream], name='Sample Stream 240p')
+    video_stream_240p = bitmovin.encodings.Stream.create(object_=video_stream_240p,
+                                                         encoding_id=encoding.id).resource                                                     
+
+    audio_stream = Stream(codec_configuration_id=audio_codec_configuration.id,
+                          input_streams=[audio_input_stream], name='Sample Stream AUDIO')
+    audio_stream = bitmovin.encodings.Stream.create(object_=audio_stream,
+                                                    encoding_id=encoding.id).resource
+
+    video_muxing_stream_720p = MuxingStream(video_stream_720p.id)
+    video_muxing_stream_480p = MuxingStream(video_stream_480p.id)
+    video_muxing_stream_360p = MuxingStream(video_stream_360p.id)
+    video_muxing_stream_240p = MuxingStream(video_stream_240p.id)
+    audio_muxing_stream = MuxingStream(audio_stream.id)
+
+    video_muxing_720p_output = EncodingOutput(output_id=s3_output.id,
+                                              output_path=OUTPUT_BASE_PATH,
+                                              acl=[acl_entry])
+    video_muxing_720p = MP4Muxing(filename='video_720p.ismv',
+                                  fragment_duration=4000,
+                                  streams=[video_muxing_stream_720p],
+                                  outputs=[video_muxing_720p_output],
+                                  name='Sample Muxing 720p')
+    video_muxing_720p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_720p,
+                                                             encoding_id=encoding.id).resource
+    playready_720p = PlayReadyDRM(key_seed=PLAYREADY_KEYSEED,
+                                  kid=PLAYREADY_KID,
+                                  method=PlayReadyMethod.PIFF_CTR,
+                                  la_url=PLAYREADY_LA_URL)
+    playready_720p = bitmovin.encodings.Muxing.MP4.DRM.PlayReady.create(object_=playready_720p,
+                                                                        encoding_id=encoding.id,
+                                                                        muxing_id=video_muxing_720p.id).resource
+
+    video_muxing_480p_output = EncodingOutput(output_id=s3_output.id,
+                                              output_path=OUTPUT_BASE_PATH,
+                                              acl=[acl_entry])
+    video_muxing_480p = MP4Muxing(filename='video_480p.ismv',
+                                  fragment_duration=4000,
+                                  streams=[video_muxing_stream_480p],
+                                  outputs=[video_muxing_480p_output],
+                                  name='Sample Muxing 480p')
+    video_muxing_480p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_480p,
+                                                             encoding_id=encoding.id).resource
+    playready_480p = PlayReadyDRM(key_seed=PLAYREADY_KEYSEED,
+                                  kid=PLAYREADY_KID,
+                                  method=PlayReadyMethod.PIFF_CTR,
+                                  la_url=PLAYREADY_LA_URL)
+    playready_480p = bitmovin.encodings.Muxing.MP4.DRM.PlayReady.create(object_=playready_480p,
+                                                                        encoding_id=encoding.id,
+                                                                        muxing_id=video_muxing_480p.id).resource
+
+    video_muxing_360p_output = EncodingOutput(output_id=s3_output.id,
+                                              output_path=OUTPUT_BASE_PATH,
+                                              acl=[acl_entry])
+    video_muxing_360p = MP4Muxing(filename='video_360p.ismv',
+                                  fragment_duration=4000,
+                                  streams=[video_muxing_stream_360p],
+                                  outputs=[video_muxing_360p_output],
+                                  name='Sample Muxing 360p')
+    video_muxing_360p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_360p,
+                                                             encoding_id=encoding.id).resource
+    playready_360p = PlayReadyDRM(key_seed=PLAYREADY_KEYSEED,
+                                  kid=PLAYREADY_KID,
+                                  method=PlayReadyMethod.PIFF_CTR,
+                                  la_url=PLAYREADY_LA_URL,
+                                  name='PlayReady')
+    playready_360p = bitmovin.encodings.Muxing.MP4.DRM.PlayReady.create(object_=playready_360p,
+                                                                        encoding_id=encoding.id,
+                                                                        muxing_id=video_muxing_360p.id).resource
+
+    video_muxing_240p_output = EncodingOutput(output_id=s3_output.id,
+                                              output_path=OUTPUT_BASE_PATH,
+                                              acl=[acl_entry])
+    video_muxing_240p = MP4Muxing(filename='video_240p.ismv',
+                                  fragment_duration=4000,
+                                  streams=[video_muxing_stream_240p],
+                                  outputs=[video_muxing_240p_output],
+                                  name='Sample Muxing 240p')
+    video_muxing_240p = bitmovin.encodings.Muxing.MP4.create(object_=video_muxing_240p,
+                                                             encoding_id=encoding.id).resource
+    playready_240p = PlayReadyDRM(key_seed=PLAYREADY_KEYSEED,
+                                  kid=PLAYREADY_KID,
+                                  method=PlayReadyMethod.PIFF_CTR,
+                                  la_url=PLAYREADY_LA_URL,
+                                  name='PlayReady')
+    playready_240p = bitmovin.encodings.Muxing.MP4.DRM.PlayReady.create(object_=playready_240p,
+                                                                        encoding_id=encoding.id,
+                                                                        muxing_id=video_muxing_240p.id).resource
+
+    audio_muxing_output = EncodingOutput(output_id=s3_output.id,
+                                              output_path=OUTPUT_BASE_PATH,
+                                              acl=[acl_entry])
+    audio_muxing = MP4Muxing(filename='audio.isma',
+                             fragment_duration=4000,
+                             streams=[audio_muxing_stream],
+                             outputs=[audio_muxing_output],
+                             name='Sample Muxing AUDIO')
+    audio_muxing = bitmovin.encodings.Muxing.MP4.create(object_=audio_muxing,
+                                                        encoding_id=encoding.id).resource
+    playready_audio = PlayReadyDRM(key_seed=PLAYREADY_KEYSEED,
+                                   kid=PLAYREADY_KID,
+                                   method=PlayReadyMethod.PIFF_CTR,
+                                   la_url=PLAYREADY_LA_URL,
+                                   name='PlayReady')
+    playready_audio = bitmovin.encodings.Muxing.MP4.DRM.PlayReady.create(object_=playready_audio,
+                                                                        encoding_id=encoding.id,
+                                                                        muxing_id=audio_muxing.id).resource
+
+    bitmovin.encodings.Encoding.start(encoding_id=encoding.id)
+
+    try:
+        bitmovin.encodings.Encoding.wait_until_finished(encoding_id=encoding.id)
+    except BitmovinError as bitmovin_error:
+        print("Exception occurred while waiting for encoding to finish: {}".format(bitmovin_error))
+
+    manifest_output = EncodingOutput(output_id=s3_output.id,
+                                     output_path=OUTPUT_BASE_PATH,
+                                     acl=[acl_entry])
+
+    smooth_manifest = SmoothManifest(server_manifest_name='example_manifest_smooth.ism',
+                                     client_manifest_name='example_manifest_smooth.ismc',
+                                     outputs=[manifest_output],
+                                     name='Sample SmoothStreaming Manifest')
+    smooth_manifest = bitmovin.manifests.Smooth.create(object_=smooth_manifest).resource
+
+    mp4_representation_audio = MP4Representation(encoding_id=encoding.id,
+                                                 muxing_id=audio_muxing.id,
+                                                 media_file='audio.isma')
+    mp4_representation_audio = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
+                                                                                  object_=mp4_representation_audio)
+
+    mp4_representation_720p = MP4Representation(encoding_id=encoding.id,
+                                                muxing_id=video_muxing_720p.id,
+                                                media_file='video_720p.ismv')
+    mp4_representation_720p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
+                                                                                 object_=mp4_representation_720p)
+
+    mp4_representation_480p = MP4Representation(encoding_id=encoding.id,
+                                                muxing_id=video_muxing_480p.id,
+                                                media_file='video_480p.ismv')
+    mp4_representation_480p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
+                                                                                 object_=mp4_representation_480p)
+
+    mp4_representation_360p = MP4Representation(encoding_id=encoding.id,
+                                                muxing_id=video_muxing_360p.id,
+                                                media_file='video_360p.ismv')
+    mp4_representation_360p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
+                                                                                 object_=mp4_representation_360p)
+
+    mp4_representation_240p = MP4Representation(encoding_id=encoding.id,
+                                                muxing_id=video_muxing_240p.id,
+                                                media_file='video_240p.ismv')
+    mp4_representation_240p = bitmovin.manifests.Smooth.MP4Representation.create(manifest_id=smooth_manifest.id,
+                                                                                 object_=mp4_representation_240p)
+
+    content_protection = SmoothContentProtection(encoding_id=encoding.id,
+                                                 muxing_id=video_muxing_720p.id,
+                                                 drm_id=playready_720p.id)
+    content_protection_audio = bitmovin.manifests.Smooth.ContentProtection.create(object_=content_protection,
+                                                                                  manifest_id=smooth_manifest.id)
+
+    bitmovin.manifests.Smooth.start(manifest_id=smooth_manifest.id)
+
+    try:
+        bitmovin.manifests.Smooth.wait_until_finished(manifest_id=smooth_manifest.id)
+    except BitmovinError as bitmovin_error:
+        print("Exception occurred while waiting for Smooth manifest creation to finish: {}".format(bitmovin_error))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/bitmovin/services/manifests/smooth/contentprotection_tests.py
+++ b/tests/bitmovin/services/manifests/smooth/contentprotection_tests.py
@@ -1,0 +1,278 @@
+import unittest
+import uuid
+from bitmovin import Bitmovin, ACLEntry, ACLPermission, EncodingOutput, Encoding, \
+    Stream, StreamInput, MuxingStream, MP4Muxing, AbstractMP4Representation, SmoothManifest, MP4Representation, \
+    SmoothContentProtection, PlayReadyDRM
+from tests.bitmovin import BitmovinTestCase
+
+
+class SmoothContentProtectionTests(BitmovinTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.bitmovin = Bitmovin(self.api_key)
+        self.assertIsNotNone(self.bitmovin)
+        self.assertTrue(isinstance(self.bitmovin, Bitmovin))
+        self.sampleEncoding = self._create_sample_encoding()  # type: Encoding
+        (self.sampleMuxing, self.sampleStream) = self._create_sample_muxing()  # type: MP4Muxing
+        self.sampleDrm = self._create_sample_drm()  # type: PlayReadyDRM
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_add_content_protection(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.Smooth.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+
+        sample_content_protection = self._get_sample_content_protection()
+        content_protection_response = self.bitmovin.manifests.Smooth.ContentProtection.create(
+            object_=sample_content_protection, manifest_id=manifest_resource_response.resource.id)
+
+        self.assertIsNotNone(content_protection_response)
+        self.assertIsNotNone(content_protection_response.resource)
+        self.assertIsNotNone(content_protection_response.resource.id)
+        self._compare_content_protections(sample_content_protection, content_protection_response.resource)
+
+    def test_list_content_protection(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.Smooth.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+
+        sample_content_protection = self._get_sample_content_protection()
+        content_protection_response = self.bitmovin.manifests.Smooth.ContentProtection.create(
+            object_=sample_content_protection, manifest_id=manifest_resource_response.resource.id)
+
+        self.assertIsNotNone(content_protection_response)
+        self.assertIsNotNone(content_protection_response.resource)
+        self.assertIsNotNone(content_protection_response.resource.id)
+        self._compare_content_protections(sample_content_protection, content_protection_response.resource)
+
+        list_content_protection_resource_response = self.bitmovin.manifests.Smooth.ContentProtection.list(manifest_id=manifest_resource_response.resource.id, limit=1)
+        self.assertIsNotNone(list_content_protection_resource_response)
+        self.assertTrue(isinstance(list_content_protection_resource_response.resource, list))
+        self.assertEqual(1, len(list_content_protection_resource_response.resource))
+
+    def test_retrieve_content_protection(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.Smooth.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+
+        sample_content_protection = self._get_sample_content_protection()
+        content_protection_response = self.bitmovin.manifests.Smooth.ContentProtection.create(
+            object_=sample_content_protection, manifest_id=manifest_resource_response.resource.id)
+
+        self.assertIsNotNone(content_protection_response)
+        self.assertIsNotNone(content_protection_response.resource)
+        self.assertIsNotNone(content_protection_response.resource.id)
+        self._compare_content_protections(sample_content_protection, content_protection_response.resource)
+
+        retrieve_content_protection_resource_response = self.bitmovin.manifests.Smooth.ContentProtection.retrieve(
+            manifest_id=manifest_resource_response.resource.id, protection_id=content_protection_response.resource.id)
+
+        self.assertIsNotNone(retrieve_content_protection_resource_response)
+        self.assertTrue(isinstance(retrieve_content_protection_resource_response.resource, SmoothContentProtection))
+        self._compare_content_protections(sample_content_protection, retrieve_content_protection_resource_response.resource)
+
+    def test_delete_content_protection(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.Smooth.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+
+        sample_content_protection = self._get_sample_content_protection()
+        content_protection_response = self.bitmovin.manifests.Smooth.ContentProtection.create(
+            object_=sample_content_protection, manifest_id=manifest_resource_response.resource.id)
+
+        self.assertIsNotNone(content_protection_response)
+        self.assertIsNotNone(content_protection_response.resource)
+        self.assertIsNotNone(content_protection_response.resource.id)
+        self._compare_content_protections(sample_content_protection, content_protection_response.resource)
+
+        delete_content_protection_resource_response = self.bitmovin.manifests.Smooth.ContentProtection.delete(
+            manifest_id=manifest_resource_response.resource.id, protection_id=content_protection_response.resource.id)
+
+        self.assertIsNotNone(delete_content_protection_resource_response)
+        self.assertIsNotNone(delete_content_protection_resource_response.resource)
+        self.assertIsNotNone(delete_content_protection_resource_response.resource.id)
+        self.assertEqual(sample_content_protection.resource.id,
+                         delete_content_protection_resource_response.resource.id)
+
+    def _compare_manifests(self, first: SmoothManifest, second: SmoothManifest):
+        self.assertEqual(first.serverManifestName, second.serverManifestName)
+        self.assertEqual(first.clientManifestName, second.clientManifestName)
+        self.assertEqual(len(first.outputs), len(second.outputs))
+        self.assertEqual(first.name, second.name)
+        self.assertEqual(first.description, second.description)
+        return True
+
+    def _compare_encodings(self, first: Encoding, second: Encoding):
+        self.assertEqual(first.name, second.name)
+        self.assertEqual(first.description, second.description)
+        self.assertEqual(first.encoderVersion, second.encoderVersion)
+        self.assertEqual(first.cloudRegion, second.cloudRegion)
+        return True
+
+    def _compare_muxings(self, first: MP4Muxing, second: MP4Muxing):
+        self.assertEqual(len(first.outputs), len(second.outputs))
+        self.assertEqual(first.fragmentDuration, second.fragmentDuration)
+        self.assertEqual(first.filename, second.filename)
+        self.assertEqual(first.name, second.name)
+        self.assertEqual(second.description, second.description)
+        return True
+
+    def _compare_content_protections(self, first: SmoothContentProtection, second: SmoothContentProtection):
+        self.assertEqual(first.encodingId, second.encodingId)
+        self.assertEqual(first.muxingId, second.muxingId)
+        self.assertEqual(first.drmId, second.drmId)
+        return True
+
+    def _compare_drms(self, first: PlayReadyDRM, second: PlayReadyDRM):
+        self.assertEqual(first.kid, second.kid)
+        self.assertEqual(first.keySeed, second.keySeed)
+        self.assertEqual(first.method, second.method)
+        self.assertEqual(first.laUrl, second.laUrl)
+        self.assertEqual(len(first.outputs), len(second.outputs))
+        self.assertEqual(first.name, second.name)
+        self.assertEqual(first.description, second.description)
+        return True
+
+    def _get_sample_manifest(self):
+        encoding_output = self._get_sample_encoding_output()
+        manifest = SmoothManifest(server_manifest_name='bitmovin-python_Sample_Smooth_Manifest.ism',
+                                  client_manifest_name='bitmovin-python_Sample_Smooth_Manifest.ismc',
+                                  outputs=[encoding_output],
+                                  name='Sample Smooth Manifest')
+
+        self.assertIsNotNone(manifest)
+        self.assertIsNotNone(manifest.serverManifestName)
+        self.assertIsNotNone(manifest.clientManifestName)
+        self.assertIsNotNone(manifest.outputs)
+        return manifest
+
+    def _get_sample_content_protection(self):
+        encoding_id = self.sampleEncoding.id
+        muxing_id = self.sampleMuxing.id
+        drm_id = self.sampleDrm.id
+
+        content_protection = SmoothContentProtection(encoding_id=encoding_id,
+                                                     muxing_id=muxing_id,
+                                                     drm_id=drm_id)
+        return content_protection
+
+    def _get_sample_encoding_output(self):
+        acl_entry = ACLEntry(scope='string', permission=ACLPermission.PUBLIC_READ)
+
+        sample_output = self.utils.get_sample_s3_output()
+        s3_output = self.bitmovin.outputs.S3.create(sample_output)
+        encoding_output = EncodingOutput(output_id=s3_output.resource.id,
+                                         output_path='/bitmovin-python/StreamTests/' + str(uuid.uuid4()),
+                                         acl=[acl_entry])
+
+        return encoding_output
+
+    def _get_sample_muxing(self):
+        stream = self._get_sample_stream()
+
+        create_stream_response = self.bitmovin.encodings.Stream.create(object_=stream,
+                                                                       encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(create_stream_response)
+        self.assertIsNotNone(create_stream_response.resource)
+        self.assertIsNotNone(create_stream_response.resource.id)
+
+        muxing_stream = MuxingStream(stream_id=create_stream_response.resource.id)
+
+        muxing = MP4Muxing(streams=[muxing_stream],
+                           filename="myrendition.ismv",
+                           fragment_duration=4000,
+                           outputs=stream.outputs,
+                           name='Sample MP4 Muxing')
+        return (muxing, create_stream_response.resource)
+
+    def _get_sample_stream(self):
+        sample_codec_configuration = self.utils.get_sample_h264_codec_configuration()
+        h264_codec_configuration = self.bitmovin.codecConfigurations.H264.create(sample_codec_configuration)
+
+        (sample_input, sample_files) = self.utils.get_sample_s3_input()
+        s3_input = self.bitmovin.inputs.S3.create(sample_input)
+        stream_input = StreamInput(input_id=s3_input.resource.id, input_path=sample_files.get('854b9c98-17b9-49ed-b75c-3b912730bfd1'), selection_mode='AUTO')
+
+        acl_entry = ACLEntry(scope='string', permission=ACLPermission.PUBLIC_READ)
+
+        sample_output = self.utils.get_sample_s3_output()
+        s3_output = self.bitmovin.outputs.S3.create(sample_output)
+        encoding_output = EncodingOutput(output_id=s3_output.resource.id,
+                                         output_path='/bitmovin-python/StreamTests/'+str(uuid.uuid4()),
+                                         acl=[acl_entry])
+
+        stream = Stream(codec_configuration_id=h264_codec_configuration.resource.id,
+                        input_streams=[stream_input],
+                        outputs=[encoding_output],
+                        name='Sample Stream')
+
+        self.assertIsNotNone(stream.codecConfigId)
+        self.assertIsNotNone(stream.inputStreams)
+        self.assertIsNotNone(stream.outputs)
+        return stream
+
+    def _create_sample_encoding(self):
+        sample_encoding = self.utils.get_sample_encoding()
+        encoding_resource_response = self.bitmovin.encodings.Encoding.create(sample_encoding)
+        self.assertIsNotNone(encoding_resource_response)
+        self.assertIsNotNone(encoding_resource_response.resource)
+        self.assertIsNotNone(encoding_resource_response.resource.id)
+        self._compare_encodings(sample_encoding, encoding_resource_response.resource)
+        return encoding_resource_response.resource
+
+    def _create_sample_muxing(self):
+        (sample_muxing, created_stream) = self._get_sample_muxing()
+        muxing_resource_response = self.bitmovin.encodings.Muxing.MP4.create(object_=sample_muxing,
+                                                                              encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(muxing_resource_response)
+        self.assertIsNotNone(muxing_resource_response.resource)
+        self.assertIsNotNone(muxing_resource_response.resource.id)
+        self._compare_muxings(sample_muxing, muxing_resource_response.resource)
+        return (muxing_resource_response.resource, created_stream)
+
+    def _create_sample_drm(self):
+        sample_drm = self._get_sample_drm_playready()
+        drm_resource_response = self.bitmovin.encodings.Muxing.MP4.DRM.PlayReady.create(
+            object_=sample_drm, encoding_id=self.sampleEncoding.id, muxing_id=self.sampleMuxing.id)
+        self.assertIsNotNone(drm_resource_response)
+        self.assertIsNotNone(drm_resource_response.resource)
+        self.assertIsNotNone(drm_resource_response.resource.id)
+        self._compare_drms(sample_drm, drm_resource_response.resource)
+        return drm_resource_response.resource
+
+    def _get_sample_drm_playready(self):
+        sample_output = self._get_sample_encoding_output()
+        sample_output.outputPath += '/drm'
+        playready_drm_settings = self.settings.get('sampleObjects').get('drmConfigurations').get('PlayReady')
+        drm = PlayReadyDRM(key_seed=playready_drm_settings[0].get('keySeed'),
+                           kid=playready_drm_settings[0].get('kid'),
+                           method=playready_drm_settings[0].get('method'),
+                           la_url=playready_drm_settings[0].get('laUrl'),
+                           name='Sample PlayReady DRM')
+        return drm
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This has the following changes:
* Add PlayReady support for Smooth Streaming packaging
* Use codec config arrays in example scripts