### PR TITLE
H264 Missing Imports

### DIFF
--- a/bitmovin/resources/enums/__init__.py
+++ b/bitmovin/resources/enums/__init__.py
@@ -55,3 +55,6 @@ from .encoding_mode import EncodingMode
 from .audio_video_sync_mode import AudioVideoSyncMode
 from .stream_mode import StreamMode
 from .playready_method import PlayReadyMethod
+from .h264_trellis import H264Trellis
+from .h264_sub_me import H264SubMe
+from .h264_motion_estimation_method import H264MotionEstimationMethod


### PR DESCRIPTION
Enable the ability to import H264 SubMe, MotionEstimationMethod and Trellis