### PR TITLE
Add list manifests by encoding ID support

### DIFF
--- a/bitmovin/services/manifests/dash_manifest_service.py
+++ b/bitmovin/services/manifests/dash_manifest_service.py
@@ -3,15 +3,15 @@ from bitmovin.errors import FunctionalityNotAvailableError, InvalidTypeError, Bi
 from bitmovin.resources import DashManifest, Period, ResourceResponse, Status, Response, AudioAdaptationSet, \
     VideoAdaptationSet, SubtitleAdaptationSet, FMP4Representation, DRMFMP4Representation, WebMRepresentation, \
     ContentProtection, DashMP4Representation, CustomXMLElement
+from bitmovin.services.manifests.generic_manifest_service import GenericManifestService
 from .manifest_control_service import ManifestControlService
-from ..rest_service import RestService
 
 
-class DASH(RestService, ManifestControlService):
-    BASE_ENDPOINT_URL = 'encoding/manifests/dash'
+class DASH(GenericManifestService, ManifestControlService):
+    manifest_type = 'dash'
 
     def __init__(self, http_client):
-        super().__init__(http_client=http_client, relative_url=self.BASE_ENDPOINT_URL, class_=DashManifest)
+        super().__init__(http_client=http_client, manifest_type=self.manifest_type, resource_class=DashManifest)
 
     def retrieve_custom_data(self, id_):
         raise FunctionalityNotAvailableError('Retrieve Custom Data is not available for DASH Manifests')

--- a/bitmovin/services/manifests/generic_manifest_service.py
+++ b/bitmovin/services/manifests/generic_manifest_service.py
@@ -1,0 +1,36 @@
+from bitmovin.resources import ResourceResponse, Status
+from bitmovin.errors import MissingArgumentError, BitmovinApiError, InvalidStatusError
+from bitmovin.services.rest_service import RestService
+
+
+class GenericManifestService(RestService):
+    BASE_ENDPOINT_URL = 'encoding/manifests/{manifest_type}'
+
+    def __init__(self, http_client, manifest_type, resource_class):
+        if not manifest_type:
+            raise MissingArgumentError('manifest_type must be given')
+        if not resource_class:
+            raise MissingArgumentError('resource_class must be given')
+        self.manifest_type = manifest_type
+        self.resource_class = resource_class
+        self.relative_url = self.BASE_ENDPOINT_URL.replace('{manifest_type}', manifest_type)
+        super().__init__(http_client=http_client, relative_url=self.relative_url, class_=resource_class)
+
+    def filter_by_encoding_id(self, encoding_id, offset=None, limit=None):
+        if not offset:
+            offset = self.DEFAULT_LIST_OFFSET_PARAM
+        if not limit:
+            limit = self.DEFAULT_LIST_LIMIT_PARAM
+        url = '{}?encodingId={}&offset={}&limit={}'.format(self.relative_url, encoding_id, offset, limit)
+        response = self.http_client.get(url)
+
+        if response.status == Status.ERROR.value:
+            raise BitmovinApiError('Response was not successful', response)
+
+        if response.status == Status.SUCCESS.value:
+            minimal_models = self.parsing_utils.parse_bitmovin_resource_list_from_response(
+                response=response, class_=self.class_)
+
+            return ResourceResponse(response=response, resource=minimal_models)
+
+        raise InvalidStatusError('Unknown status {} received'.format(response.status))

--- a/bitmovin/services/manifests/hls_manifest_service.py
+++ b/bitmovin/services/manifests/hls_manifest_service.py
@@ -1,7 +1,7 @@
 from bitmovin.resources import HlsManifest
+from bitmovin.services.manifests.generic_manifest_service import GenericManifestService
 
 from .manifest_control_service import ManifestControlService
-from ..rest_service import RestService
 
 from .video_media_service import Video
 from .audio_media_service import Audio
@@ -11,11 +11,11 @@ from .closed_captions_media_service import ClosedCaptions
 from .variant_stream_service import VariantStreamService
 
 
-class HLS(RestService, ManifestControlService):
-    BASE_ENDPOINT_URL = 'encoding/manifests/hls'
+class HLS(GenericManifestService, ManifestControlService):
+    manifest_type = 'hls'
 
     def __init__(self, http_client):
-        super().__init__(http_client=http_client, relative_url=self.BASE_ENDPOINT_URL, class_=HlsManifest)
+        super().__init__(http_client=http_client, manifest_type=self.manifest_type, resource_class=HlsManifest)
 
         self.VideoMedia = Video(http_client=http_client)
         self.AudioMedia = Audio(http_client=http_client)

--- a/bitmovin/services/manifests/smooth_manifest_service.py
+++ b/bitmovin/services/manifests/smooth_manifest_service.py
@@ -1,15 +1,15 @@
 from bitmovin.resources import SmoothManifest
+from bitmovin.services.manifests.generic_manifest_service import GenericManifestService
 from .manifest_control_service import ManifestControlService
-from ..rest_service import RestService
 from .smooth_representation_service import MP4RepresentationService
 from .smooth_content_protection_service import SmoothContentProtectionService
 
 
-class Smooth(RestService, ManifestControlService):
-    BASE_ENDPOINT_URL = 'encoding/manifests/smooth'
+class Smooth(GenericManifestService, ManifestControlService):
+    manifest_type = 'smooth'
 
     def __init__(self, http_client):
-        super().__init__(http_client=http_client, relative_url=self.BASE_ENDPOINT_URL, class_=SmoothManifest)
+        super().__init__(http_client=http_client, manifest_type=self.manifest_type, resource_class=SmoothManifest)
 
         self.MP4Representation = MP4RepresentationService(http_client=http_client)
         self.ContentProtection = SmoothContentProtectionService(http_client=http_client)

--- a/tests/bitmovin/services/manifests/dash/dash_manifest_tests.py
+++ b/tests/bitmovin/services/manifests/dash/dash_manifest_tests.py
@@ -1,7 +1,8 @@
 import unittest
 import uuid
 from bitmovin import Bitmovin, Response, DashManifest, ACLEntry, ACLPermission, EncodingOutput, \
-    DashManifestProfile, DASHNamespace
+    DashManifestProfile, DASHNamespace, Stream, StreamInput, FMP4Muxing, MuxingStream, DashMP4Representation, Period, \
+    VideoAdaptationSet
 from bitmovin.errors import BitmovinApiError
 from tests.bitmovin import BitmovinTestCase
 
@@ -21,6 +22,8 @@ class DashManifestTests(BitmovinTestCase):
         self.bitmovin = Bitmovin(self.api_key)
         self.assertIsNotNone(self.bitmovin)
         self.assertTrue(isinstance(self.bitmovin, Bitmovin))
+        self.sampleEncoding = self._create_sample_encoding()  # type: Encoding
+        self.sampleMuxing = self._create_sample_muxing()  # type: FMP4Muxing
 
     def tearDown(self):
         super().tearDown()
@@ -125,6 +128,43 @@ class DashManifestTests(BitmovinTestCase):
         self.assertIsInstance(manifests.response, Response)
         self.assertGreater(manifests.resource.__sizeof__(), 1)
 
+    def test_list_manifests_by_encoding_id(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.DASH.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+        sample_period = self._get_sample_period_default()
+        period_resource_response = self.bitmovin.manifests.DASH.add_period(
+            object_=sample_period, manifest_id=manifest_resource_response.resource.id)
+        self.assertIsNotNone(period_resource_response)
+        self.assertIsNotNone(period_resource_response.resource)
+        self.assertIsNotNone(period_resource_response.resource.id)
+        sample_adaptationset = self._get_sample_adaptationset()
+        adaptationset_resource_response = self.bitmovin.manifests.DASH.add_video_adaptation_set(
+            object_=sample_adaptationset, manifest_id=manifest_resource_response.resource.id,
+            period_id=period_resource_response.resource.id
+        )
+        self.assertIsNotNone(adaptationset_resource_response)
+        self.assertIsNotNone(adaptationset_resource_response.resource)
+        self.assertIsNotNone(adaptationset_resource_response.resource.id)
+        sample_representation = self._get_sample_mp4_representation()
+        representation_resource_response = self.bitmovin.manifests.DASH.add_mp4_representation(
+            object_=sample_representation, manifest_id=manifest_resource_response.resource.id,
+            period_id=period_resource_response.resource.id, adaptationset_id=adaptationset_resource_response.resource.id
+        )
+
+        manifests = self.bitmovin.manifests.DASH.filter_by_encoding_id(encoding_id=self.sampleEncoding.id)
+
+        self.assertIsNotNone(manifests)
+        self.assertIsNotNone(manifests.resource)
+        self.assertIsNotNone(manifests.response)
+        self.assertIsInstance(manifests.resource, list)
+        self.assertIsInstance(manifests.response, Response)
+        self.assertEqual(manifests.resource[0].id, manifest_resource_response.resource.id)
+        self.assertGreater(manifests.resource.__sizeof__(), 1)
+
     def _compare_manifests(self, first: DashManifest, second: DashManifest):
         """
 
@@ -174,6 +214,85 @@ class DashManifestTests(BitmovinTestCase):
                                          acl=[acl_entry])
 
         return encoding_output
+
+    def _get_sample_period_default(self):
+        period = Period()
+        return period
+
+    def _get_sample_adaptationset(self):
+        video_adaptationset = VideoAdaptationSet()
+        return video_adaptationset
+
+    def _get_sample_mp4_representation(self):
+        encoding_id = self.sampleEncoding.id
+        muxing_id = self.sampleMuxing.id
+        mp4_representation = DashMP4Representation(encoding_id=encoding_id,
+                                                   muxing_id=muxing_id,
+                                                   file_path='/path/to/file.mp4')
+
+        return mp4_representation
+
+    def _get_sample_muxing(self):
+        stream = self._get_sample_stream()
+
+        create_stream_response = self.bitmovin.encodings.Stream.create(object_=stream,
+                                                                       encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(create_stream_response)
+        self.assertIsNotNone(create_stream_response.resource)
+        self.assertIsNotNone(create_stream_response.resource.id)
+
+        muxing_stream = MuxingStream(stream_id=create_stream_response.resource.id)
+
+        muxing = FMP4Muxing(streams=[muxing_stream],
+                            segment_length=4,
+                            segment_naming='seg_%number%.m4s',
+                            init_segment_name='init.mp4',
+                            outputs=stream.outputs,
+                            name='Sample FMP4 Muxing')
+        return muxing
+
+    def _get_sample_stream(self):
+        sample_codec_configuration = self.utils.get_sample_h264_codec_configuration()
+        h264_codec_configuration = self.bitmovin.codecConfigurations.H264.create(sample_codec_configuration)
+
+        (sample_input, sample_files) = self.utils.get_sample_s3_input()
+        s3_input = self.bitmovin.inputs.S3.create(sample_input)
+        stream_input = StreamInput(input_id=s3_input.resource.id, input_path=sample_files.get('854b9c98-17b9-49ed-b75c-3b912730bfd1'), selection_mode='AUTO')
+
+        acl_entry = ACLEntry(scope='string', permission=ACLPermission.PUBLIC_READ)
+
+        sample_output = self.utils.get_sample_s3_output()
+        s3_output = self.bitmovin.outputs.S3.create(sample_output)
+        encoding_output = EncodingOutput(output_id=s3_output.resource.id,
+                                         output_path='/bitmovin-python/StreamTests/'+str(uuid.uuid4()),
+                                         acl=[acl_entry])
+
+        stream = Stream(codec_configuration_id=h264_codec_configuration.resource.id,
+                        input_streams=[stream_input],
+                        outputs=[encoding_output],
+                        name='Sample Stream')
+
+        self.assertIsNotNone(stream.codecConfigId)
+        self.assertIsNotNone(stream.inputStreams)
+        self.assertIsNotNone(stream.outputs)
+        return stream
+
+    def _create_sample_encoding(self):
+        sample_encoding = self.utils.get_sample_encoding()
+        encoding_resource_response = self.bitmovin.encodings.Encoding.create(sample_encoding)
+        self.assertIsNotNone(encoding_resource_response)
+        self.assertIsNotNone(encoding_resource_response.resource)
+        self.assertIsNotNone(encoding_resource_response.resource.id)
+        return encoding_resource_response.resource
+
+    def _create_sample_muxing(self):
+        sample_muxing = self._get_sample_muxing()
+        muxing_resource_response = self.bitmovin.encodings.Muxing.FMP4.create(object_=sample_muxing,
+                                                                              encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(muxing_resource_response)
+        self.assertIsNotNone(muxing_resource_response.resource)
+        self.assertIsNotNone(muxing_resource_response.resource.id)
+        return muxing_resource_response.resource
 
 
 if __name__ == '__main__':

--- a/tests/bitmovin/services/manifests/dash/dash_manifest_tests.py
+++ b/tests/bitmovin/services/manifests/dash/dash_manifest_tests.py
@@ -163,7 +163,7 @@ class DashManifestTests(BitmovinTestCase):
         self.assertIsInstance(manifests.resource, list)
         self.assertIsInstance(manifests.response, Response)
         self.assertEqual(manifests.resource[0].id, manifest_resource_response.resource.id)
-        self.assertGreater(manifests.resource.__sizeof__(), 1)
+        self.assertEqual(len(manifests.resource), 1)
 
     def _compare_manifests(self, first: DashManifest, second: DashManifest):
         """

--- a/tests/bitmovin/services/manifests/hls/hls_manifest_tests.py
+++ b/tests/bitmovin/services/manifests/hls/hls_manifest_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import uuid
-from bitmovin import Bitmovin, Response, ACLEntry, ACLPermission, EncodingOutput, HlsManifest
+from bitmovin import Bitmovin, Response, ACLEntry, ACLPermission, EncodingOutput, HlsManifest, MuxingStream, FMP4Muxing, \
+    StreamInput, Stream, VariantStream
 from bitmovin.errors import BitmovinApiError
 from tests.bitmovin import BitmovinTestCase
 
@@ -20,6 +21,8 @@ class HlsManifestTests(BitmovinTestCase):
         self.bitmovin = Bitmovin(self.api_key)
         self.assertIsNotNone(self.bitmovin)
         self.assertTrue(isinstance(self.bitmovin, Bitmovin))
+        self.sampleEncoding = self._create_sample_encoding()  # type: Encoding
+        (self.sampleMuxing, self.sampleStream) = self._create_sample_muxing()  # type: FMP4Muxing
 
     def tearDown(self):
         super().tearDown()
@@ -92,6 +95,32 @@ class HlsManifestTests(BitmovinTestCase):
         self.assertIsInstance(manifests.response, Response)
         self.assertGreater(manifests.resource.__sizeof__(), 1)
 
+    def test_list_manifests_by_encoding_id(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.HLS.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+
+        sample_variant_stream = self._get_sample_variant_stream()
+        variant_stream_resource_response = self.bitmovin.manifests.HLS.VariantStream.create(
+            object_=sample_variant_stream, manifest_id=manifest_resource_response.resource.id)
+
+        self.assertIsNotNone(variant_stream_resource_response)
+        self.assertIsNotNone(variant_stream_resource_response.resource)
+        self.assertIsNotNone(variant_stream_resource_response.resource.id)
+
+        manifests = self.bitmovin.manifests.HLS.filter_by_encoding_id(encoding_id=self.sampleEncoding.id)
+
+        self.assertIsNotNone(manifests)
+        self.assertIsNotNone(manifests.resource)
+        self.assertIsNotNone(manifests.response)
+        self.assertIsInstance(manifests.resource, list)
+        self.assertIsInstance(manifests.response, Response)
+        self.assertEqual(manifests.resource[0].id, manifest_resource_response.resource.id)
+        self.assertGreater(manifests.resource.__sizeof__(), 1)
+
     def _compare_manifests(self, first: HlsManifest, second: HlsManifest):
         self.assertEqual(first.manifestName, second.manifestName)
         self.assertEqual(len(first.outputs), len(second.outputs))
@@ -110,6 +139,18 @@ class HlsManifestTests(BitmovinTestCase):
         self.assertIsNotNone(manifest.outputs)
         return manifest
 
+    def _get_sample_variant_stream(self):
+        encoding_id = self.sampleEncoding.id
+        stream_id = self.sampleStream.id
+        muxing_id = self.sampleMuxing.id
+
+        variant_stream = VariantStream(audio='audio_grp', video='video_grp', subtitles='subtitles_grp',
+                                       closed_captions='NONE', segment_path='/path/to/segs', uri='playlist.m3u8',
+                                       encoding_id=encoding_id, stream_id=stream_id, muxing_id=muxing_id,
+                                       start_segment_number=0)
+
+        return variant_stream
+
     def _get_sample_encoding_output(self):
         acl_entry = ACLEntry(scope='string', permission=ACLPermission.PUBLIC_READ)
 
@@ -120,6 +161,68 @@ class HlsManifestTests(BitmovinTestCase):
                                          acl=[acl_entry])
 
         return encoding_output
+
+    def _get_sample_muxing(self):
+        stream = self._get_sample_stream()
+
+        create_stream_response = self.bitmovin.encodings.Stream.create(object_=stream,
+                                                                       encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(create_stream_response)
+        self.assertIsNotNone(create_stream_response.resource)
+        self.assertIsNotNone(create_stream_response.resource.id)
+
+        muxing_stream = MuxingStream(stream_id=create_stream_response.resource.id)
+
+        muxing = FMP4Muxing(streams=[muxing_stream],
+                            segment_length=4,
+                            segment_naming='seg_%number%.m4s',
+                            init_segment_name='init.mp4',
+                            outputs=stream.outputs,
+                            name='Sample FMP4 Muxing')
+        return (muxing, create_stream_response.resource)
+
+    def _get_sample_stream(self):
+        sample_codec_configuration = self.utils.get_sample_h264_codec_configuration()
+        h264_codec_configuration = self.bitmovin.codecConfigurations.H264.create(sample_codec_configuration)
+
+        (sample_input, sample_files) = self.utils.get_sample_s3_input()
+        s3_input = self.bitmovin.inputs.S3.create(sample_input)
+        stream_input = StreamInput(input_id=s3_input.resource.id, input_path=sample_files.get('854b9c98-17b9-49ed-b75c-3b912730bfd1'), selection_mode='AUTO')
+
+        acl_entry = ACLEntry(scope='string', permission=ACLPermission.PUBLIC_READ)
+
+        sample_output = self.utils.get_sample_s3_output()
+        s3_output = self.bitmovin.outputs.S3.create(sample_output)
+        encoding_output = EncodingOutput(output_id=s3_output.resource.id,
+                                         output_path='/bitmovin-python/StreamTests/'+str(uuid.uuid4()),
+                                         acl=[acl_entry])
+
+        stream = Stream(codec_configuration_id=h264_codec_configuration.resource.id,
+                        input_streams=[stream_input],
+                        outputs=[encoding_output],
+                        name='Sample Stream')
+
+        self.assertIsNotNone(stream.codecConfigId)
+        self.assertIsNotNone(stream.inputStreams)
+        self.assertIsNotNone(stream.outputs)
+        return stream
+
+    def _create_sample_encoding(self):
+        sample_encoding = self.utils.get_sample_encoding()
+        encoding_resource_response = self.bitmovin.encodings.Encoding.create(sample_encoding)
+        self.assertIsNotNone(encoding_resource_response)
+        self.assertIsNotNone(encoding_resource_response.resource)
+        self.assertIsNotNone(encoding_resource_response.resource.id)
+        return encoding_resource_response.resource
+
+    def _create_sample_muxing(self):
+        (sample_muxing, created_stream) = self._get_sample_muxing()
+        muxing_resource_response = self.bitmovin.encodings.Muxing.FMP4.create(object_=sample_muxing,
+                                                                              encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(muxing_resource_response)
+        self.assertIsNotNone(muxing_resource_response.resource)
+        self.assertIsNotNone(muxing_resource_response.resource.id)
+        return (muxing_resource_response.resource, created_stream)
 
 
 if __name__ == '__main__':

--- a/tests/bitmovin/services/manifests/hls/hls_manifest_tests.py
+++ b/tests/bitmovin/services/manifests/hls/hls_manifest_tests.py
@@ -119,7 +119,7 @@ class HlsManifestTests(BitmovinTestCase):
         self.assertIsInstance(manifests.resource, list)
         self.assertIsInstance(manifests.response, Response)
         self.assertEqual(manifests.resource[0].id, manifest_resource_response.resource.id)
-        self.assertGreater(manifests.resource.__sizeof__(), 1)
+        self.assertEqual(len(manifests.resource), 1)
 
     def _compare_manifests(self, first: HlsManifest, second: HlsManifest):
         self.assertEqual(first.manifestName, second.manifestName)

--- a/tests/bitmovin/services/manifests/smooth/smooth_manifest_tests.py
+++ b/tests/bitmovin/services/manifests/smooth/smooth_manifest_tests.py
@@ -115,7 +115,7 @@ class SmoothManifestTests(BitmovinTestCase):
         self.assertIsInstance(manifests.resource, list)
         self.assertIsInstance(manifests.response, Response)
         self.assertEqual(manifests.resource[0].id, manifest_resource_response.resource.id)
-        self.assertGreater(manifests.resource.__sizeof__(), 1)
+        self.assertEqual(len(manifests.resource), 1)
 
     def _compare_manifests(self, first: SmoothManifest, second: SmoothManifest):
         self.assertEqual(first.serverManifestName, second.serverManifestName)

--- a/tests/bitmovin/services/manifests/smooth/smooth_manifest_tests.py
+++ b/tests/bitmovin/services/manifests/smooth/smooth_manifest_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import uuid
-from bitmovin import Bitmovin, Response, ACLEntry, ACLPermission, EncodingOutput, SmoothManifest
+from bitmovin import Bitmovin, Response, ACLEntry, ACLPermission, EncodingOutput, SmoothManifest, StreamInput, Stream, \
+    MuxingStream, MP4Muxing, MP4Representation
 from bitmovin.errors import BitmovinApiError
 from tests.bitmovin import BitmovinTestCase
 
@@ -20,6 +21,8 @@ class SmoothManifestTests(BitmovinTestCase):
         self.bitmovin = Bitmovin(self.api_key)
         self.assertIsNotNone(self.bitmovin)
         self.assertTrue(isinstance(self.bitmovin, Bitmovin))
+        self.sampleEncoding = self._create_sample_encoding()  # type: Encoding
+        (self.sampleMuxing, self.sampleStream) = self._create_sample_muxing()  # type: MP4Muxing
 
     def tearDown(self):
         super().tearDown()
@@ -92,6 +95,28 @@ class SmoothManifestTests(BitmovinTestCase):
         self.assertIsInstance(manifests.response, Response)
         self.assertGreater(manifests.resource.__sizeof__(), 1)
 
+    def test_list_manifests_by_encoding_id(self):
+        sample_manifest = self._get_sample_manifest()
+        manifest_resource_response = self.bitmovin.manifests.Smooth.create(sample_manifest)
+        self.assertIsNotNone(manifest_resource_response)
+        self.assertIsNotNone(manifest_resource_response.resource)
+        self.assertIsNotNone(manifest_resource_response.resource.id)
+        self._compare_manifests(sample_manifest, manifest_resource_response.resource)
+
+        sample_mp4_representation = self._get_sample_mp4_representation()
+        mp4_representation_response = self.bitmovin.manifests.Smooth.MP4Representation.create(
+            object_=sample_mp4_representation, manifest_id=manifest_resource_response.resource.id)
+
+        manifests = self.bitmovin.manifests.Smooth.filter_by_encoding_id(encoding_id=self.sampleEncoding.id)
+
+        self.assertIsNotNone(manifests)
+        self.assertIsNotNone(manifests.resource)
+        self.assertIsNotNone(manifests.response)
+        self.assertIsInstance(manifests.resource, list)
+        self.assertIsInstance(manifests.response, Response)
+        self.assertEqual(manifests.resource[0].id, manifest_resource_response.resource.id)
+        self.assertGreater(manifests.resource.__sizeof__(), 1)
+
     def _compare_manifests(self, first: SmoothManifest, second: SmoothManifest):
         self.assertEqual(first.serverManifestName, second.serverManifestName)
         self.assertEqual(first.clientManifestName, second.clientManifestName)
@@ -125,6 +150,84 @@ class SmoothManifestTests(BitmovinTestCase):
 
         return encoding_output
 
+    def _get_sample_muxing(self):
+        stream = self._get_sample_stream()
+
+        create_stream_response = self.bitmovin.encodings.Stream.create(object_=stream,
+                                                                       encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(create_stream_response)
+        self.assertIsNotNone(create_stream_response.resource)
+        self.assertIsNotNone(create_stream_response.resource.id)
+
+        muxing_stream = MuxingStream(stream_id=create_stream_response.resource.id)
+
+        muxing = MP4Muxing(streams=[muxing_stream],
+                           filename="myrendition.ismv",
+                           fragment_duration=4000,
+                           outputs=stream.outputs,
+                           name='Sample MP4 Muxing')
+        return muxing, create_stream_response.resource
+
+    def _get_sample_stream(self):
+        sample_codec_configuration = self.utils.get_sample_h264_codec_configuration()
+        h264_codec_configuration = self.bitmovin.codecConfigurations.H264.create(sample_codec_configuration)
+
+        (sample_input, sample_files) = self.utils.get_sample_s3_input()
+        s3_input = self.bitmovin.inputs.S3.create(sample_input)
+        stream_input = StreamInput(input_id=s3_input.resource.id,
+                                   input_path=sample_files.get('854b9c98-17b9-49ed-b75c-3b912730bfd1'),
+                                   selection_mode='AUTO')
+
+        acl_entry = ACLEntry(scope='string', permission=ACLPermission.PUBLIC_READ)
+
+        sample_output = self.utils.get_sample_s3_output()
+        s3_output = self.bitmovin.outputs.S3.create(sample_output)
+        encoding_output = EncodingOutput(output_id=s3_output.resource.id,
+                                         output_path='/bitmovin-python/StreamTests/'+str(uuid.uuid4()),
+                                         acl=[acl_entry])
+
+        stream = Stream(codec_configuration_id=h264_codec_configuration.resource.id,
+                        input_streams=[stream_input],
+                        outputs=[encoding_output],
+                        name='Sample Stream')
+
+        self.assertIsNotNone(stream.codecConfigId)
+        self.assertIsNotNone(stream.inputStreams)
+        self.assertIsNotNone(stream.outputs)
+        return stream
+
+    def _get_sample_mp4_representation(self):
+        encoding_id = self.sampleEncoding.id
+        muxing_id = self.sampleMuxing.id
+
+        media_file = 'myrendition.ismv'
+        language = 'some_language'
+        track_name = 'some_track'
+
+        mp4_representation = MP4Representation(encoding_id=encoding_id,
+                                               muxing_id=muxing_id,
+                                               media_file=media_file,
+                                               language=language,
+                                               track_name=track_name)
+        return mp4_representation
+
+    def _create_sample_encoding(self):
+        sample_encoding = self.utils.get_sample_encoding()
+        encoding_resource_response = self.bitmovin.encodings.Encoding.create(sample_encoding)
+        self.assertIsNotNone(encoding_resource_response)
+        self.assertIsNotNone(encoding_resource_response.resource)
+        self.assertIsNotNone(encoding_resource_response.resource.id)
+        return encoding_resource_response.resource
+
+    def _create_sample_muxing(self):
+        (sample_muxing, created_stream) = self._get_sample_muxing()
+        muxing_resource_response = self.bitmovin.encodings.Muxing.MP4.create(object_=sample_muxing,
+                                                                             encoding_id=self.sampleEncoding.id)
+        self.assertIsNotNone(muxing_resource_response)
+        self.assertIsNotNone(muxing_resource_response.resource)
+        self.assertIsNotNone(muxing_resource_response.resource.id)
+
+        return muxing_resource_response.resource, created_stream
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add support for retrieving manifests by encoding ID
- Refactored the dash/hls/smooth manifest services to extend a GenericManifestService that itself extends the RestService

### PR Checklist 

- [ ] Code is PEP8 conform (https://www.python.org/dev/peps/pep-0008/)
- [ ] PR contains tests for code changes
