### PR TITLE
feature/remove full rd enum

### DIFF
--- a/bitmovin/resources/enums/h264_sub_me.py
+++ b/bitmovin/resources/enums/h264_sub_me.py
@@ -13,4 +13,3 @@ class H264SubMe(enum.Enum):
     RD_REF_IP = 'RD_REF_IP'
     RD_REF_ALL = 'RD_REF_ALL'
     QPRD = 'QPRD'
-    FULL_RD = 'FULL_RD'

--- a/bitmovin/resources/factories/H264CodecConfigurationFactory.py
+++ b/bitmovin/resources/factories/H264CodecConfigurationFactory.py
@@ -54,7 +54,7 @@ class H264CodecConfigurationFactory():
         config.cabac = True
         config.rc_lookahead = 60
         config.refFrames = 16
-        config.sub_me = H264SubMe.FULL_RD
+        config.sub_me = H264SubMe.QPRD
         config.trellis = H264Trellis.ENABLED_ALL
         config.partitions = [H264Partition.ALL]
 


### PR DESCRIPTION
FULL_RD slows down H264 encodes by 40% and does not improve quality.

### PR Checklist 

- [x] Code is PEP8 conform (https://www.python.org/dev/peps/pep-0008/)
- [x] PR contains tests for code changes
